### PR TITLE
Feature undomove added

### DIFF
--- a/C++ Chess Engine/C++ Chess Engine/main.cpp
+++ b/C++ Chess Engine/C++ Chess Engine/main.cpp
@@ -2258,7 +2258,8 @@ void main() {
                               }
                          }
                     }
-                    saveCurrentState();
+                    savedBoard[halfMoveCount] = currentBoard;
+                    halfMoveCount++;
                     int userMove[3] = { initialSquare, terminalSquare, moveType};
                     // save terminalValue for undoMove;
                     lastTerminalValue = makeMove(currentBoard, userMove);
@@ -2394,7 +2395,8 @@ void main() {
           }
           else if (currentBoard.getTurn() == -userColor || spectate == true) {
                
-               saveCurrentState();
+               savedBoard[halfMoveCount] = currentBoard;
+               halfMoveCount++;
 
                int alphabetaMove[3];
                int alphabetaValue = rootAlphabeta(EVAL_DEPTH, currentBoard, -999999, 999999, alphabetaMove);

--- a/C++ Chess Engine/C++ Chess Engine/main.cpp
+++ b/C++ Chess Engine/C++ Chess Engine/main.cpp
@@ -148,11 +148,6 @@ int savedTerminalValue[MAX_MOVENUMBER]; // TODO: Check if it should be initializ
 int savedMove[MAX_MOVENUMBER + 1][3];
 bool savedCastlingCheck[MAX_MOVENUMBER + 1][4];
 int savedEnpassantSquare[MAX_MOVENUMBER] = { 0, };
-int lastTerminalValue = ERROR_INTEGER; // data input in makemove, used in undomove
-int lastMove[3] = { ERROR_INTEGER, ERROR_INTEGER, ERROR_INTEGER }; // data input in makemove, used in undomove
-bool lastCastlingCheck[4];
-int lastEnpassantSquare = 0;
-
 
 //  Which color user plays
 int userColor = ERROR_INTEGER;
@@ -903,13 +898,6 @@ bool checkGameEnd(Board& board) {
           if (board.getSquare(i) == BLACKKING) { blackKing = true; }
      }
      return !(whiteKing && blackKing);
-}
-void saveCurrentState() {
-     savedBoard[halfMoveCount] = currentBoard;
-     //  TODO: Check repetition here
-
-     //  Better place might be elsewhere
-     halfMoveCount++;
 }
 
 /*                           MOVE GENERATION FUNCTIONS                        */

--- a/C++ Chess Engine/C++ Chess Engine/main.cpp
+++ b/C++ Chess Engine/C++ Chess Engine/main.cpp
@@ -2264,6 +2264,9 @@ void main() {
                          savedMove[halfMoveCount][i] = userMove[i];
                     }
 
+                    savedBoard[halfMoveCount] = currentBoard;
+                    halfMoveCount++;
+
                     // add to log file
                     logtext << currentBoard.getMoveNumber() << ": " << numberToFile(userMove[0]) << numberToRank(userMove[0]) << " " << numberToFile(userMove[1]) << numberToRank(userMove[1]) << endl;
 

--- a/C++ Chess Engine/C++ Chess Engine/main.cpp
+++ b/C++ Chess Engine/C++ Chess Engine/main.cpp
@@ -2258,11 +2258,11 @@ void main() {
                               }
                          }
                     }
-                    savedBoard[halfMoveCount] = currentBoard;
-                    halfMoveCount++;
+                    
                     int userMove[3] = { initialSquare, terminalSquare, moveType};
                     // save terminalValue for undoMove;
                     lastTerminalValue = makeMove(currentBoard, userMove);
+                    
                     for (int i = 0; i < 3; i++) {
                          lastMove[i] = userMove[i];
                     }
@@ -2324,7 +2324,7 @@ void main() {
                else if (commandType == UNDO_MOVE) {
                     //  TODO: Use saved instead of last
                     //  TerminalSquare needs to be saved
-                    if (lastTerminalValue == ERROR_INTEGER) {
+                    if (lastTerminalValue == ERROR_INTEGER || halfMoveCount == 0) {
                          printf("No move can be undone!\n");
                          continue;
                     }

--- a/C++ Chess Engine/C++ Chess Engine/main.cpp
+++ b/C++ Chess Engine/C++ Chess Engine/main.cpp
@@ -2337,6 +2337,7 @@ void main() {
                          continue;
                     }
                     else {
+                         halfMoveCount--;
                          undoMove(currentBoard, savedMove[halfMoveCount], savedTerminalValue[halfMoveCount]);
                     }
 

--- a/C++ Chess Engine/C++ Chess Engine/main.cpp
+++ b/C++ Chess Engine/C++ Chess Engine/main.cpp
@@ -141,7 +141,19 @@ LARGE_INTEGER frequency, beginTime, endTime;
 int gameResult = NOT_FINISHED;
 //  Stores Board and Board States for threefold repetition
 Board savedBoard[MAX_MOVENUMBER + 1];
+//  Number of times the savedBoard state has occured
 int repetitionCount[MAX_MOVENUMBER + 1];
+//  Saved values for UNDO_MOVE command
+int savedTerminalValue[MAX_MOVENUMBER]; // TODO: Check if it should be initialized as ERROR_INTEGER
+int savedMove[MAX_MOVENUMBER + 1][3];
+int savedCastlingCheck[MAX_MOVENUMBER + 1][4];
+int savedEnpassantSquare[MAX_MOVENUMBER] = { 0, };
+int lastTerminalValue = ERROR_INTEGER; // data input in makemove, used in undomove
+int lastMove[3] = { ERROR_INTEGER, ERROR_INTEGER, ERROR_INTEGER }; // data input in makemove, used in undomove
+bool lastCastlingCheck[4];
+int lastEnpassantSquare = 0;
+
+
 //  Which color user plays
 int userColor = ERROR_INTEGER;
 //  To create a log of moves
@@ -2034,11 +2046,8 @@ void main() {
      //  begin timer
      frequency = startTimer(&beginTime, 1);
      
+
      //  Game Loop: Player vs COM
-     int lastTerminalValue = ERROR_INTEGER; // data input in makemove, used in undomove
-     int lastMove[3] = { ERROR_INTEGER, ERROR_INTEGER, ERROR_INTEGER }; // data input in makemove, used in undomove
-     bool lastCastlingCheck[4];
-     int lastEnpassantSquare = 0;
      bool correctInput = false;
      string userCommand;
 


### PR DESCRIPTION
I should do a quick hotfix on updating all the variables in the saved board when a move is made by player or computer.

Also, possibly undoMove can be simplified by just saying currentBoard = savedBoard[halfMoveCount], but this is the stable version for now.
