### PR TITLE
FENboardsetup end of string problem fixed

### DIFF
--- a/C++ Chess Engine/C++ Chess Engine/main.cpp
+++ b/C++ Chess Engine/C++ Chess Engine/main.cpp
@@ -329,7 +329,7 @@ void FENboardSetup(const std::string FEN) {
      }
      
      // One-digit Move Number
-     if (FEN.at(i + 1) == ' ') {
+     if (FEN.length() == i+1 || FEN.at(i + 1) == ' ') {
           currentBoard.setMoveNumber(FEN.at(i) - '0');
      }
      // Two-digit Move Number


### PR DESCRIPTION
In other places if there is nothing after it it is an incomplete fen so
it does not matter. (unless FENboardsetup will be included in the menu)
